### PR TITLE
Fix login screen on small screens (mobile)

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,7 +456,7 @@ const layout = (config) => ({
     <style>
     html,
 body {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {


### PR DESCRIPTION
On small screens parts of the login screen are hidden and it was not possible to scroll upwards. Now it is

Please be aware that this issue also exists in other themes (material, sbadmin)

Before:
![grafik](https://user-images.githubusercontent.com/7558512/202911047-73e25f0e-fbb1-4c47-aed5-332063189b5d.png)

After:
![grafik](https://user-images.githubusercontent.com/7558512/202911081-7d87748f-a690-4148-a324-0dcf38f9e355.png)
(notice scrollbar)
